### PR TITLE
add api key to initial admin user

### DIFF
--- a/mysql/user.sql
+++ b/mysql/user.sql
@@ -1,6 +1,6 @@
 LOCK TABLES `users` WRITE;
 /*!40000 ALTER TABLE `users` DISABLE KEYS */;
-INSERT INTO `users` VALUES (1,'admin','$2a$10$SW9AmmAlVCM3OSkzMzCEb.NpYXQ67qG5lBmk7U85YbXWhTkTZwEXi','admin','','all','0','2016-10-06 23:21:50');
+INSERT INTO `users` VALUES (1,'admin','$2a$10$SW9AmmAlVCM3OSkzMzCEb.NpYXQ67qG5lBmk7U85YbXWhTkTZwEXi','admin','','all','abc123','0','2016-10-06 23:21:50');
 /*!40000 ALTER TABLE `users` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
initial installer fails to create the admin user due to column count mismatch (api in db, not in user creation sql). probably this should be rando gen'd. /shrug